### PR TITLE
Double merge error

### DIFF
--- a/src/hooks/useBoard.js
+++ b/src/hooks/useBoard.js
@@ -1,13 +1,16 @@
 import { useState, useEffect } from 'react'
 import { createBoard, gameFinished, newTile, randomIndex, slideUp, slideDown, slideRight, slideLeft, isDifferent, placeNewTile, generateNewGame } from '../utils/BoardUtilities'
 
+/**
+ * Hook to handle the functionality of the game 
+ */
 function useBoard(){
   const [tiles, setTiles] = useState(createBoard())
   const [gameOver, setGameOver] = useState(false)
   const [turns, setTurns] = useState(0)
 
-  // anytime the tiles array changes, 
-  // check to see if the game is complete 
+  /* anytime the tiles array changes, 
+   * check to see if the game is complete */ 
   useEffect(() => {
     setGameOver(gameFinished(tiles))
   }, [tiles])
@@ -45,15 +48,8 @@ function useBoard(){
 
     /* Increment turn counter */
     if(isDifferent(newBoard,tiles)) {
-      console.log('its different')
-      console.log('old', tiles, 'new', newBoard)
-      const board = placeNewTile(newBoard)
-      console.log('placing tile', board)
-      // setTurns(turns + 1) 
+      setTurns(turns + 1) 
       setTiles(placeNewTile(newBoard)) 
-    } else {
-      console.log('its the same')
-      console.log("old", tiles, "new", newBoard);
     }
   }
 

--- a/src/utils/BoardUtilities.js
+++ b/src/utils/BoardUtilities.js
@@ -89,7 +89,11 @@ export function gameFinished(tiles) {
  * Move the tiles upward on the board 
  * returning a new board with all the tiles 
  * positions moved toward the top 
- * @param {Array<number>} board
+ * 
+ * Note: This function is called recursively until no more moves 
+ * can be made 
+ * @param {Array<number>} board - the board 
+ * @param {Array<number>} mergedIndices - and indexes that have already been merged 
  * @returns {Array<number} newBoard 
  */
 export function slideUp(board, mergedIndices = []) {
@@ -99,14 +103,14 @@ export function slideUp(board, mergedIndices = []) {
   // all the tiles with values
   const mappedTiles = newBoard
     .map((value, index) => ({ value, indicies: { old: index, new: getIndex("up", index) }}))
-    .filter((tiles) => tiles.value !== 0)
+    .filter((tile) => tile.value !== 0 && !mergedIndices.includes(tile.indicies.new))
     .sort(sortTilesByIndex);
 
   /* figure out how many tiles moved by counting the ones
    * that have the same new/previous values  */
   const tilesToMove = mappedTiles
     .filter(tile => tile.indicies.new !== tile.indicies.old)
-    .length
+    .length 
 
 
   // if no tiles were moved, there is no more
@@ -120,15 +124,6 @@ export function slideUp(board, mergedIndices = []) {
       if (tilesToMove === unMoveableTiles) {
         // no more tiles to move 
         return newBoard; 
-      } else if (mergedIndices.includes(mappedTiles[i].indicies.new)) {
-        // if the destination is in the tiles merged
-        // and the number of tiles left to move is 1, 
-        // then this is the last merge
-        if (tilesToMove === (unMoveableTiles + mergedIndices.length)) {
-          return newBoard
-        }
-        unMoveableTiles++;
-        continue;
       } else if (mappedTiles[i].indicies.new === mappedTiles[i].indicies.old) {
         // tiles with the same index do not move
         continue;
@@ -148,7 +143,6 @@ export function slideUp(board, mergedIndices = []) {
         // won't be re-merged within the same turn
         mergedIndices.push(mappedTiles[i].indicies.new);
       } else {
-        console.log("unmovable tile found");
         // the tiles have different values and cannot be merged
         unMoveableTiles++;
         continue;


### PR DESCRIPTION
Filtered out any indexes that have already been added in the recursive sliding of tiles on the board... this should prevent a double merge 